### PR TITLE
Upgrade maven-dependency-tree version to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
-            <version>3.2.1</version>
+            <version>3.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
- [ ] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----
This PR resolves a compile-time vs runtime dependency mismatch - maven-dependency-tree:3.2.1 provided the necessary interfaces at build time, but at runtime it was missing the actual implementation classes (DependencyGraphBuilder), causing ClassNotFoundException when attempting a tree construction at some cases