### PR TITLE
XRAY-145307 - Implemented logic to include plugins deps as well in dep tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ to generate the dependency tree for projects using Maven dependencies.
     - [Tree](#-tree)
         - [Output](#output)
         - [Output Tree Structure](#output-tree-structure)
+        - [Including Build-Plugin Dependencies](#including-build-plugin-dependencies)
     - [Project Info](#-project-info)
         - [Output](#output-1)
 - [Contributions](#-contributions)
@@ -65,6 +66,19 @@ mvn com.jfrog:maven-dep-tree:tree -DdepsTreeOutputFile=<path/to/output/file>
   }
 }
 ```
+
+#### Including Build-Plugin Dependencies
+
+Set `-DincludePluginDeps=true` (default `false`) to also resolve build plugins in the install
+lifecycle and their transitive dependencies. These are downloaded during `mvn install` but are
+invisible to `mvn dependency:tree`.
+
+```bash
+mvn com.jfrog:maven-dep-tree:tree -DdepsTreeOutputFile=<path/to/output/file> -DincludePluginDeps=true
+```
+
+The output then includes a `pluginNodes` map (same structure as `nodes`), omitted when the flag is
+off and empty when no plugin dependencies are found.
 
 ### 🧐 Project Info
 

--- a/src/main/java/com/jfrog/mavendeptree/MavenDependencyTree.java
+++ b/src/main/java/com/jfrog/mavendeptree/MavenDependencyTree.java
@@ -3,6 +3,7 @@ package com.jfrog.mavendeptree;
 import com.jfrog.mavendeptree.dependenciesresults.MavenDepTreeResults;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.LifecycleExecutor;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
@@ -12,6 +13,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
+import org.eclipse.aether.RepositorySystem;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -44,10 +46,36 @@ public class MavenDependencyTree extends AbstractMojo {
     @Component(hint = "default")
     private DependencyGraphBuilder dependencyGraphBuilder;
 
+    // Aether repository system for resolving plugin transitive dependencies
+    @Component
+    private RepositorySystem repositorySystem;
+
+    // Used to discover lifecycle-default plugin bindings (e.g. maven-compiler-plugin on compile)
+    @Component
+    private LifecycleExecutor lifecycleExecutor;
+
+    /**
+     * When true, Maven build plugins that participate in the install lifecycle, together with
+     * their transitive dependencies, are included in the output under the {@code pluginNodes}
+     * field. These artifacts are downloaded during {@code mvn install} but are invisible to
+     * {@code mvn dependency:tree}. Default is false to preserve existing behaviour.
+     */
+    @Parameter(property = "includePluginDeps", defaultValue = "false")
+    private boolean includePluginDeps;
+
     @Override
     public void execute() throws MojoExecutionException {
         try (FileWriter fileWriter = new FileWriter(depsTreeOutputFile, true)) {
             MavenDepTreeResults results = createDependencyTree(dependencyGraphBuilder, session, project);
+
+            if (includePluginDeps) {
+                PluginDependencyResolver resolver = new PluginDependencyResolver(
+                        repositorySystem, lifecycleExecutor, session, project, getLog());
+                // Always set when enabled (even if empty) so the JSON is unambiguous:
+                // null = off, {} = on but none found, populated = found.
+                results.setPluginNodes(resolver.resolvePluginDependencies());
+            }
+
             File resultsPath = writeResultsToFile(project, results);
             fileWriter.append(resultsPath.getAbsolutePath()).append(lineSeparator());
         } catch (DependencyGraphBuilderException | IOException e) {

--- a/src/main/java/com/jfrog/mavendeptree/PluginDependencyResolver.java
+++ b/src/main/java/com/jfrog/mavendeptree/PluginDependencyResolver.java
@@ -1,0 +1,307 @@
+package com.jfrog.mavendeptree;
+
+import com.jfrog.mavendeptree.dependenciesresults.MavenDependencyNode;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.LifecycleExecutor;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.ArtifactProperties;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Resolves Maven build plugins that participate in the {@code install} lifecycle, together
+ * with their transitive dependencies, using Maven's Aether repository system. Both the plugin
+ * artifacts themselves and their transitive closure are reported.
+ *
+ * <p>Both explicitly-declared POM plugins and lifecycle-default bindings (e.g. the
+ * maven-compiler-plugin bound to {@code compile} by default for {@code jar} packaging)
+ * are included. This mirrors what {@code mvn dependency:resolve-plugins} reports.
+ *
+ * <p>The resolver is intentionally non-fatal: any plugin or artifact that cannot be
+ * resolved is logged and skipped, so the regular dependency tree is never broken.
+ */
+public class PluginDependencyResolver {
+
+    /**
+     * Phases NOT executed by {@code mvn install} (the entire clean and site lifecycles, plus
+     * the default lifecycle's post-install {@code deploy}). A plugin whose every execution
+     * targets only these is excluded. {@code integration-test}/{@code verify} run before
+     * install, so they are intentionally not listed.
+     */
+    private static final Set<String> PHASES_NOT_IN_INSTALL = new HashSet<>(Arrays.asList(
+            "pre-clean", "clean", "post-clean",
+            "pre-site", "site", "post-site", "site-deploy",
+            "deploy",
+            // "none" is the Maven idiom to disable an execution (not a real lifecycle phase).
+            "none"
+    ));
+
+    /**
+     * Plugins excluded by default because their default-bound lifecycle phase is past
+     * {@code install} (or outside it), even when the effective POM declares them without
+     * explicit {@code <executions>}. Excluded unless the user explicitly re-binds them
+     * to an earlier phase.
+     */
+    private static final Set<String> EXCLUDED_PLUGINS_BY_DEFAULT = new HashSet<>(Arrays.asList(
+            "org.apache.maven.plugins:maven-deploy-plugin",
+            "org.apache.maven.plugins:maven-site-plugin",
+            "org.apache.maven.plugins:maven-release-plugin",
+            "org.apache.maven.plugins:maven-gpg-plugin"
+    ));
+
+    private final RepositorySystem repositorySystem;
+    private final LifecycleExecutor lifecycleExecutor;
+    private final MavenSession session;
+    private final MavenProject project;
+    private final Log log;
+
+    public PluginDependencyResolver(RepositorySystem repositorySystem,
+                                    LifecycleExecutor lifecycleExecutor,
+                                    MavenSession session,
+                                    MavenProject project,
+                                    Log log) {
+        this.repositorySystem = repositorySystem;
+        this.lifecycleExecutor = lifecycleExecutor;
+        this.session = session;
+        this.project = project;
+        this.log = log;
+    }
+
+    /**
+     * Returns a map of {@code "groupId:artifactId:version" -> MavenDependencyNode} for every build
+     * plugin that participates in the install lifecycle and each of its transitive dependencies
+     * (the plugin artifacts themselves are included alongside their closure).
+     *
+     * <p>Both explicitly-declared plugins (from {@code project.getBuildPlugins()}) and
+     * lifecycle-default bindings are included, deduped by GAV.
+     */
+    public Map<String, MavenDependencyNode> resolvePluginDependencies() {
+        Map<String, MavenDependencyNode> pluginDeps = new LinkedHashMap<>();
+
+        // Collect all effective plugins: explicitly declared + lifecycle-default bindings.
+        Map<String, Plugin> effectivePlugins = collectEffectivePlugins();
+        if (effectivePlugins.isEmpty()) {
+            log.debug("[mvn-plugin-deps] no build plugins found for this project");
+            return pluginDeps;
+        }
+
+        // Resolved once and reused for every plugin. It can be null on unusual embedder/IDE
+        // invocations; bail out gracefully rather than letting Aether throw an NPE.
+        RepositorySystemSession repoSession = session.getRepositorySession();
+        if (repoSession == null) {
+            log.debug("[mvn-plugin-deps] no repository session available; skipping plugin dependency resolution");
+            return pluginDeps;
+        }
+
+        int filteredOut = 0;
+        for (Plugin plugin : effectivePlugins.values()) {
+            String coord = plugin.getGroupId() + ":" + plugin.getArtifactId();
+            if (!isPluginInInstallLifecycle(plugin)) {
+                log.debug("[mvn-plugin-deps] plugin filtered (not in install lifecycle): " + coord);
+                filteredOut++;
+                continue;
+            }
+            log.debug("[mvn-plugin-deps] resolving transitive deps for plugin: " + coord + ":" + plugin.getVersion());
+            int before = pluginDeps.size();
+            resolvePluginTransitiveDeps(plugin, repoSession, pluginDeps);
+            log.debug(String.format("[mvn-plugin-deps]   -> %d new transitive deps collected (total so far: %d)",
+                    pluginDeps.size() - before, pluginDeps.size()));
+        }
+
+        log.debug(String.format("[mvn-plugin-deps] DONE: %d plugin transitive deps included after install-lifecycle filter (%d plugins filtered out)",
+                pluginDeps.size(), filteredOut));
+        return pluginDeps;
+    }
+
+    /**
+     * Returns a merged map of all effective build plugins for this project:
+     * explicitly declared ones from the POM plus lifecycle-default bindings obtained
+     * via {@link LifecycleExecutor#calculateExecutionPlan}.
+     * Keyed by {@code "groupId:artifactId"}.
+     *
+     * <p>If the execution plan can't be calculated, falls back to plugin-management defaults
+     * so blocked plugin dependencies are still not missed (matches the previous CLI behaviour).
+     * That fallback is permissive and may over-report (see {@link #addPluginManagementFallback}).
+     */
+    private Map<String, Plugin> collectEffectivePlugins() {
+        Map<String, Plugin> plugins = new LinkedHashMap<>();
+
+        // 1. Explicitly declared plugins from the POM (including inherited from parent).
+        List<Plugin> buildPlugins = project.getBuildPlugins();
+        if (buildPlugins != null) {
+            for (Plugin p : buildPlugins) {
+                plugins.put(p.getGroupId() + ":" + p.getArtifactId(), p);
+            }
+        }
+
+        // 2. Lifecycle-default bindings — e.g. maven-compiler-plugin bound to 'compile'
+        //    for jar packaging. These don't appear in getBuildPlugins() unless explicitly
+        //    declared, but ARE downloaded and used during mvn install. The execution plan
+        //    is the most accurate source for both the plugin set and their resolved versions.
+        try {
+            for (MojoExecution execution : lifecycleExecutor
+                    .calculateExecutionPlan(session, "install")
+                    .getMojoExecutions()) {
+                addPlugin(plugins, execution.getPlugin(), "lifecycle-default");
+            }
+        } catch (Exception e) {
+            // Broad by design: calculateExecutionPlan throws many checked exceptions and can also
+            // fail at runtime (offline/curation-restricted). Fall back to plugin-management defaults
+            // rather than dropping the lifecycle-default plugins this feature exists to scan.
+            log.warn("[mvn-plugin-deps] could not calculate the install execution plan; falling back to " +
+                    "plugin-management defaults. No blocked plugin dependency will be missed, but results may " +
+                    "over-report: plugins declared in <pluginManagement> but not actually executed by 'mvn install' " +
+                    "can contribute transitive dependencies. Reason: " + e.getMessage());
+            addPluginManagementFallback(plugins);
+        }
+
+        return plugins;
+    }
+
+    /**
+     * Adds the effective plugin-management plugins (which include the super-POM defaults
+     * and their versions) as a permissive fallback when the execution plan is unavailable.
+     * Plugins that still lack a version are skipped later during resolution.
+     *
+     * <p>Note: {@code <pluginManagement>} only declares versions/config; it does not bind
+     * plugins to the build. So this can include plugins that {@code mvn install} would never
+     * execute, causing transitive deps to be over-reported. This is an accepted trade-off on
+     * the (rare) execution-plan failure path — it favours not missing a blocked dependency
+     * over precision — and is surfaced to the user via a warning at the call site.
+     */
+    private void addPluginManagementFallback(Map<String, Plugin> plugins) {
+        if (project.getPluginManagement() == null) {
+            return;
+        }
+        for (Plugin p : project.getPluginManagement().getPlugins()) {
+            addPlugin(plugins, p, "fallback plugin-management");
+        }
+    }
+
+    private void addPlugin(Map<String, Plugin> plugins, Plugin plugin, String source) {
+        String key = plugin.getGroupId() + ":" + plugin.getArtifactId();
+        if (!plugins.containsKey(key)) {
+            plugins.put(key, plugin);
+            log.debug("[mvn-plugin-deps] " + source + " plugin: " + key + ":" + plugin.getVersion());
+        }
+    }
+
+    /**
+     * Returns true when the plugin participates in {@code mvn install}. With no explicit
+     * {@code <phase>}, the plugin is included unless it is in {@link #EXCLUDED_PLUGINS_BY_DEFAULT}
+     * — deliberately erring toward inclusion (a false positive is safer than missing a blocked
+     * dependency), matching the previous CLI behaviour.
+     */
+    static boolean isPluginInInstallLifecycle(Plugin plugin) {
+        String coord = plugin.getGroupId() + ":" + plugin.getArtifactId();
+        List<PluginExecution> executions = plugin.getExecutions();
+
+        // Stage 1: an explicitly-bound execution on an install-lifecycle phase means the plugin
+        // participates. An execution with no phase isn't "explicit" - it inherits the default
+        // binding (stage 2). Phases in PHASES_NOT_IN_INSTALL (and "none") never participate.
+        boolean hasExplicitPhase = false;
+        for (PluginExecution execution : executions) {
+            String phase = execution.getPhase();
+            if (phase == null || phase.isEmpty()) {
+                continue;
+            }
+            hasExplicitPhase = true;
+            if (!PHASES_NOT_IN_INSTALL.contains(phase)) {
+                return true;
+            }
+        }
+
+        // Stage 2: no explicit phase - fall back to the default binding, included unless excluded.
+        if (!hasExplicitPhase) {
+            return !EXCLUDED_PLUGINS_BY_DEFAULT.contains(coord);
+        }
+
+        // Explicit phase(s) present but all non-install -> does not participate.
+        return false;
+    }
+
+    /**
+     * Resolves the given plugin and its transitive artifact closure via Aether and populates
+     * {@code pluginDeps}. The plugin artifact itself is included; GAVs already collected
+     * (keyed including classifier) are skipped to avoid duplicates.
+     */
+    private void resolvePluginTransitiveDeps(Plugin plugin, RepositorySystemSession repoSession, Map<String, MavenDependencyNode> pluginDeps) {
+        String groupId = plugin.getGroupId();
+        String artifactId = plugin.getArtifactId();
+        String version = plugin.getVersion();
+
+        if (version == null || version.isEmpty()) {
+            log.debug("[mvn-plugin-deps] skipping plugin with no version: " + groupId + ":" + artifactId);
+            return;
+        }
+
+        Dependency pluginDep = new Dependency(
+                new DefaultArtifact(groupId, artifactId, "jar", version), null);
+
+        CollectRequest collectRequest = new CollectRequest(pluginDep, project.getRemotePluginRepositories());
+        DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, null);
+
+        DependencyResult result;
+        try {
+            result = repositorySystem.resolveDependencies(repoSession, dependencyRequest);
+        } catch (Exception e) {
+            // Broad on purpose: a single rogue plugin (resolution failure, or an NPE from an
+            // odd embedder session) must never break the whole dependency tree.
+            log.warn("[mvn-plugin-deps] failed to resolve plugin " + groupId + ":" + artifactId + ":" + version + " — " + e.getMessage());
+            return;
+        }
+
+        // PreorderNodeListGenerator flattens the resolved graph into a de-duplicated node list,
+        // correctly handling diamond dependencies (shared sub-trees are visited once, not dropped).
+        PreorderNodeListGenerator nlg = new PreorderNodeListGenerator();
+        result.getRoot().accept(nlg);
+        for (DependencyNode dn : nlg.getNodes()) {
+            org.eclipse.aether.artifact.Artifact a = dn.getArtifact();
+            if (a == null) {
+                continue;
+            }
+            // The resolution root is the plugin artifact itself, included alongside its transitive
+            // deps: the plugin JAR is downloaded during 'mvn install' and is itself a curation candidate.
+            String gav = pluginDepKey(a);
+            if (pluginDeps.containsKey(gav)) {
+                continue;
+            }
+            String classifier = a.getClassifier();
+            String scope = dn.getDependency() != null ? dn.getDependency().getScope() : null;
+            // Use the Maven artifact type (e.g. "test-jar", "maven-plugin") to match the semantics
+            // of the regular dependency nodes; fall back to the Aether extension when absent.
+            String type = a.getProperty(ArtifactProperties.TYPE, a.getExtension());
+            pluginDeps.put(gav, new MavenDependencyNode(scope, type,
+                    (classifier != null && !classifier.isEmpty()) ? classifier : null));
+        }
+    }
+
+    /**
+     * Builds the dedup key for a resolved plugin dependency. Includes the classifier so that
+     * classifier-distinct artifacts (e.g. a {@code :tests} jar) do not collide. Mirrors the
+     * {@code groupId:artifactId:version[-classifier]} format used by {@code Utils.getGavString}.
+     */
+    private static String pluginDepKey(org.eclipse.aether.artifact.Artifact a) {
+        String gav = a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getVersion();
+        String classifier = a.getClassifier();
+        return (classifier != null && !classifier.isEmpty()) ? gav + "-" + classifier : gav;
+    }
+}

--- a/src/main/java/com/jfrog/mavendeptree/dependenciesresults/MavenDepTreeResults.java
+++ b/src/main/java/com/jfrog/mavendeptree/dependenciesresults/MavenDepTreeResults.java
@@ -8,6 +8,13 @@ import java.util.Map;
 public class MavenDepTreeResults {
     private String root;
     private Map<String, MavenDependencyNode> nodes;
+    // Build plugins (and their transitive deps) resolved when includePluginDeps=true.
+    // Kept separate from nodes so the CLI can distinguish project deps from plugin deps
+    // and apply curation checks only to the relevant artifact types.
+    // Null when plugin dependency resolution was not requested, or when it was requested
+    // but no plugin dependencies were found. Resolution itself is non-fatal: individual
+    // plugin/artifact failures are logged and skipped rather than producing a null result.
+    private Map<String, MavenDependencyNode> pluginNodes;
 
     // Empty constructor for deserialization
     @SuppressWarnings("unused")
@@ -25,5 +32,13 @@ public class MavenDepTreeResults {
 
     public Map<String, MavenDependencyNode> getNodes() {
         return nodes;
+    }
+
+    public Map<String, MavenDependencyNode> getPluginNodes() {
+        return pluginNodes;
+    }
+
+    public void setPluginNodes(Map<String, MavenDependencyNode> pluginNodes) {
+        this.pluginNodes = pluginNodes;
     }
 }

--- a/src/test/java/com/jfrog/mavendeptree/PluginDependencyResolverTest.java
+++ b/src/test/java/com/jfrog/mavendeptree/PluginDependencyResolverTest.java
@@ -1,0 +1,87 @@
+package com.jfrog.mavendeptree;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for the install-lifecycle filtering in {@link PluginDependencyResolver}.
+ * {@link PluginDependencyResolver#isPluginInInstallLifecycle(Plugin)} is pure logic over the
+ * Maven model (static, no collaborators), so it is called directly. Aether-backed resolution
+ * is covered by the integration tests.
+ */
+public class PluginDependencyResolverTest {
+
+    @Test
+    public void testExplicitInstallPhaseIncluded() {
+        assertTrue(PluginDependencyResolver.isPluginInInstallLifecycle(plugin("org.example", "custom-plugin", "compile")));
+        assertTrue(PluginDependencyResolver.isPluginInInstallLifecycle(plugin("org.example", "custom-plugin", "package")));
+        assertTrue(PluginDependencyResolver.isPluginInInstallLifecycle(plugin("org.example", "custom-plugin", "verify")));
+        assertTrue(PluginDependencyResolver.isPluginInInstallLifecycle(plugin("org.example", "custom-plugin", "integration-test")));
+    }
+
+    @Test
+    public void testExplicitPostInstallPhaseExcluded() {
+        assertFalse(PluginDependencyResolver.isPluginInInstallLifecycle(plugin("org.example", "custom-plugin", "deploy")));
+        assertFalse(PluginDependencyResolver.isPluginInInstallLifecycle(plugin("org.example", "custom-plugin", "site")));
+        assertFalse(PluginDependencyResolver.isPluginInInstallLifecycle(plugin("org.example", "custom-plugin", "clean")));
+    }
+
+    @Test
+    public void testAnyInstallPhaseWinsOverPostInstall() {
+        Plugin plugin = plugin("org.example", "custom-plugin", "deploy");
+        plugin.addExecution(execution("package"));
+        assertTrue(PluginDependencyResolver.isPluginInInstallLifecycle(plugin));
+    }
+
+    @Test
+    public void testNoExecutionsIncludedByDefault() {
+        assertTrue(PluginDependencyResolver.isPluginInInstallLifecycle(plugin("org.example", "custom-plugin", null)));
+        assertTrue(PluginDependencyResolver.isPluginInInstallLifecycle(
+                plugin("org.apache.maven.plugins", "maven-jar-plugin", null)));
+    }
+
+    @Test
+    public void testNoExplicitPhaseFallsBackToDefault() {
+        // Execution present but without a phase -> treated as default-bound, so included unless excluded.
+        Plugin plugin = plugin("org.example", "custom-plugin", null);
+        plugin.addExecution(execution(null));
+        assertTrue(PluginDependencyResolver.isPluginInInstallLifecycle(plugin));
+    }
+
+    @Test
+    public void testExcludedByDefaultWithoutExplicitPhase() {
+        assertFalse(PluginDependencyResolver.isPluginInInstallLifecycle(
+                plugin("org.apache.maven.plugins", "maven-deploy-plugin", null)));
+        assertFalse(PluginDependencyResolver.isPluginInInstallLifecycle(
+                plugin("org.apache.maven.plugins", "maven-site-plugin", null)));
+        assertFalse(PluginDependencyResolver.isPluginInInstallLifecycle(
+                plugin("org.apache.maven.plugins", "maven-gpg-plugin", null)));
+    }
+
+    @Test
+    public void testExcludedByDefaultIsReincludedWhenBoundToInstallPhase() {
+        // A user can re-bind an excluded plugin to an install-lifecycle phase.
+        Plugin plugin = plugin("org.apache.maven.plugins", "maven-deploy-plugin", "package");
+        assertTrue(PluginDependencyResolver.isPluginInInstallLifecycle(plugin));
+    }
+
+    private static Plugin plugin(String groupId, String artifactId, String phase) {
+        Plugin plugin = new Plugin();
+        plugin.setGroupId(groupId);
+        plugin.setArtifactId(artifactId);
+        if (phase != null) {
+            plugin.addExecution(execution(phase));
+        }
+        return plugin;
+    }
+
+    private static PluginExecution execution(String phase) {
+        PluginExecution execution = new PluginExecution();
+        execution.setPhase(phase);
+        return execution;
+    }
+}

--- a/src/test/java/com/jfrog/mavendeptree/integration/MavenDepTreeITest.java
+++ b/src/test/java/com/jfrog/mavendeptree/integration/MavenDepTreeITest.java
@@ -22,7 +22,10 @@ import static com.jfrog.mavendeptree.Utils.createMapper;
 import static com.jfrog.mavendeptree.integration.Utils.getPluginVersion;
 import static com.jfrog.mavendeptree.integration.Utils.runMavenDepTree;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author yahavi
@@ -71,6 +74,37 @@ public class MavenDepTreeITest {
                 assertEquals(mavenDependencyTree.getNodes().get("junit:junit:3.8.1"), new MavenDependencyNode("test", "jar", null));
             }
         }
+    }
+
+    @Test
+    public void testIncludePluginDeps() throws VerificationException, IOException {
+        // With -DincludePluginDeps=true the build plugins' transitive dependencies are resolved via
+        // Aether and emitted under "pluginNodes". This exercises the full resolution + traversal path.
+        List<String> depsTreeOutputFiles = runMavenDepTree("plugin-deps", testOutputDir, pluginVersion, "-DincludePluginDeps=true");
+        assertEquals(depsTreeOutputFiles.size(), 1);
+
+        MavenDepTreeResults results = mapper.readValue(new File(depsTreeOutputFiles.get(0)), MavenDepTreeResults.class);
+
+        Map<String, MavenDependencyNode> pluginNodes = results.getPluginNodes();
+        assertNotNull(pluginNodes, "pluginNodes must be set when -DincludePluginDeps=true");
+        assertFalse(pluginNodes.isEmpty(), "expected the install-lifecycle build plugins to contribute deps");
+        // An install-lifecycle plugin (compile phase) and its transitive deps are included -
+        // the plugin artifact itself is reported too.
+        assertTrue(pluginNodes.containsKey("org.apache.maven.plugins:maven-compiler-plugin:3.8.0"),
+                "an install-lifecycle plugin artifact must be included in pluginNodes");
+        // A plugin bound to a post-install phase (deploy) is filtered out.
+        assertFalse(pluginNodes.containsKey("org.apache.maven.plugins:maven-deploy-plugin:2.8.2"),
+                "a post-install plugin must be excluded from pluginNodes");
+    }
+
+    @Test
+    public void testPluginDepsOmittedByDefault() throws VerificationException, IOException {
+        // Without the flag, pluginNodes is null (feature off), preserving the existing output contract.
+        List<String> depsTreeOutputFiles = runMavenDepTree("plugin-deps", testOutputDir, pluginVersion);
+        assertEquals(depsTreeOutputFiles.size(), 1);
+
+        MavenDepTreeResults results = mapper.readValue(new File(depsTreeOutputFiles.get(0)), MavenDepTreeResults.class);
+        assertNull(results.getPluginNodes(), "pluginNodes must be null when -DincludePluginDeps is not set");
     }
 
     @Test

--- a/src/test/java/com/jfrog/mavendeptree/integration/Utils.java
+++ b/src/test/java/com/jfrog/mavendeptree/integration/Utils.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.jfrog.mavendeptree.Utils.createMapper;
@@ -53,11 +54,12 @@ public class Utils {
      * @param projectName   - The test project to run
      * @param testOutputDir - Output test directory
      * @param pluginVersion - The plugin version
+     * @param extraArgs     - Additional Maven arguments to append (e.g. "-DincludePluginDeps=true")
      * @return the content of the generated 'depsTreeOutputFile' file.
      * @throws IOException           in case of any unexpected I/O error.
      * @throws VerificationException in case of any Maven Verifier error.
      */
-    static List<String> runMavenDepTree(String projectName, String testOutputDir, String pluginVersion) throws IOException, VerificationException {
+    static List<String> runMavenDepTree(String projectName, String testOutputDir, String pluginVersion, String... extraArgs) throws IOException, VerificationException {
         Path depsTreeOutputFilePath = Paths.get(testOutputDir, "depsTreeOutputFile");
 
         File testDir = ResourceExtractor.simpleExtractResources(Utils.class, "/integration/" + projectName);
@@ -65,7 +67,9 @@ public class Utils {
         if (StringUtils.equalsIgnoreCase(System.getProperty("debugITs"), "true")) {
             verifier.setEnvironmentVariable("MAVEN_OPTS", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
         }
-        verifier.executeGoals(Lists.newArrayList("clean", "com.jfrog:maven-dep-tree:" + pluginVersion + ":tree", "-DdepsTreeOutputFile=" + depsTreeOutputFilePath));
+        List<String> goals = Lists.newArrayList("clean", "com.jfrog:maven-dep-tree:" + pluginVersion + ":tree", "-DdepsTreeOutputFile=" + depsTreeOutputFilePath);
+        goals.addAll(Arrays.asList(extraArgs));
+        verifier.executeGoals(goals);
         verifier.verifyErrorFreeLog();
         return FileUtils.readLines(depsTreeOutputFilePath.toFile(), StandardCharsets.UTF_8);
     }

--- a/src/test/resources/integration/plugin-deps/pom.xml
+++ b/src/test/resources/integration/plugin-deps/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>plugin-deps</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>plugin-deps</name>
+    <description>Project used to verify build-plugin transitive dependency resolution (includePluginDeps).</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- Pin plugin versions so the resolved plugin transitive closure is deterministic. -->
+        <plugins>
+            <!-- A build plugin that participates in the install lifecycle (compile phase) and has
+                 its own transitive dependencies, which must show up under pluginNodes. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+            </plugin>
+            <!-- A plugin bound to a post-install phase; its deps must NOT be included. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.7.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>


### PR DESCRIPTION
## Summary
Adds opt-in resolution of Maven build-plugin transitive dependencies to the dep tree, gated behind `-DincludePluginDeps=true` (default off). Output is exposed as a new `pluginNodes` map on `MavenDepTreeResults`, sibling to the existing `nodes` map. Filtering: install-lifecycle plugins only — plugins bound exclusively to `pre-clean`/`clean`/`site*`/`deploy` or `<phase>none</phase>`, and the `deploy`/`site`/`release`/`gpg` plugins, are excluded.

JSON contract is backward-compatible: `pluginNodes` is omitted (`@JsonInclude(NON_NULL)`) when the flag is off, so existing consumers see no schema change.

## Consumer
Paired with [jfrog-cli-security#776](https://github.com/jfrog/jfrog-cli-security/pull/776) (XRAY-145307), which switches the CLI's plugin-dep path from shelling out to `mvn dependency:resolve-plugins` to reading this field. CLI version bump lands once a release of `maven-dep-tree` is cut.

## Tests
- New integration test [`testIncludePluginDeps`](src/test/java/com/jfrog/mavendeptree/integration/MavenDepTreeITest.java) exercises the full Aether path against a real Maven build (asserts compiler-plugin transitives included, deploy-plugin excluded).
- New unit test [`PluginDependencyResolverTest`](src/test/java/com/jfrog/mavendeptree/PluginDependencyResolverTest.java) covers lifecycle-filter edge cases.

<img width="1212" height="361" alt="Screenshot 2026-06-16 at 9 06 58 AM" src="https://github.com/user-attachments/assets/b3c60f5b-7484-4259-8231-6de763ce04db" />


- [ ] All [tests](../CONTRIBUTING.md#tests) passed. If this feature is not already covered by the tests, I added new
  tests.

-----
