### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,11 @@
     <properties>
         <!-- CAUTION: Modifying the Maven version may cause disruptions for numerous users. Avoid altering it. -->
         <maven.min.version>3.6.3</maven.min.version>
+        <maven.api.version>3.8.1</maven.api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <jackson.version>2.15.2</jackson.version>
+        <jackson.version>2.18.6</jackson.version>
         <skipITs>true</skipITs>
     </properties>
 
@@ -75,7 +76,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${maven.min.version}</version>
+            <version>${maven.api.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -89,7 +90,17 @@
                     <groupId>org.sonatype.plexus</groupId>
                     <artifactId>plexus-cipher</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
             </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.6.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -106,6 +117,17 @@
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-shared-utils</artifactId>
             <version>3.4.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -117,7 +139,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.18.0</version>
         </dependency>
 
         <!--Jackson-->
@@ -162,7 +184,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
-            <version>${maven.min.version}</version>
+            <version>${maven.api.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## `fix(deps): upgrade vulnerable dependencies`

## Summary
Updates `pom.xml` dependency versions to resolve security findings from the dependency scan (Frogbot). The minimum supported Maven version for users (`maven.min.version` = 3.6.3) is unchanged; compile-time Maven API dependencies are bumped separately via a new `maven.api.version` property.

## Changes
- Add `maven.api.version` (3.8.1) for `maven-core` and `maven-compat`, fixing CVE-2021-26291
- Bump Jackson from 2.15.2 to 2.18.6, fixing CVE-2023-35116 and jackson-core findings
- Bump `commons-lang3` from 3.12.0 to 3.18.0, fixing CVE-2025-48924
- Pin `commons-io` to 2.14.0 (exclude transitive from `maven-shared-utils`), fixing CVE-2024-47554
- Pin `plexus-utils` to 3.6.1 (exclude transitive from `maven-core`), fixing CVE-2025-67030

## Notes
- `maven.min.version` remains **3.6.3** so the plugin’s documented minimum Maven prerequisite is unchanged.
- `maven-core` stays `provided` scope; only the compile-time API version was raised.